### PR TITLE
Allow overriding the Squid package name

### DIFF
--- a/roles/server/defaults/main.yml
+++ b/roles/server/defaults/main.yml
@@ -21,6 +21,7 @@
 
 squid_state: present
 squid_cfg_template: mafalb.squid.server.conf.j2
+squid_package_name: squid
 squid_cfg: {}
 
 ...

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: squid is present
   package:
-    name: squid
+    name: "{{ squid_package_name }}"
 
 - name: debug squid_cfg_template
   debug: var=squid_cfg_template


### PR DESCRIPTION
Ubuntu 22.04 was released recently and it includes two mutually exclusive packages for installing different "flavours" of Squid. The service name is `squid` in both of them.

|package name|flavour|
|---------------|-------|
|[squid](https://packages.ubuntu.com/jammy/squid)|GnuTLS flavour|
|[squid-openssl](https://packages.ubuntu.com/jammy/squid-openssl)|OpenSSL flavour|

This PR adds a new `squid_package_name` variable allowing the user to override the default package name of `squid`.